### PR TITLE
edited .cls to fit smith format

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -5,8 +5,7 @@ date: 'May 20xx'
 institution: 'Smith College'
 division: 'Mathematics and Natural Sciences'
 advisor: 'Advisor F. Name'
-# If you have more two advisors, un-silence line 7
-#altadvisor: 'Your Other Advisor'
+altadvisor: 'Your Other Advisor'
 department: 'Statistical & Data Scieces'
 degree: 'Bachelor of Arts'
 knit: bookdown::render_book

--- a/inst/rmarkdown/templates/thesis/skeleton/smiththesis.cls
+++ b/inst/rmarkdown/templates/thesis/skeleton/smiththesis.cls
@@ -300,50 +300,22 @@
     \null\vfil
     {\fontsize{12}{14}\selectfont \@title}
     \vfil
-    \centerline{\hbox to \wd0 {\hbox{}\hrulefill\hbox{}}}
+    \@author
     \vfil
-    A Thesis \\
-    Presented to \\
-    \@thedivisionof \ \@division \\
-    \@institution
-    \vfil
-    \centerline{\hbox to \wd0 {\hbox{}\hrulefill\hbox{}}}
-    \vfil
-    In Partial Fulfillment \\
-    of the Requirements for the Degree \\
+    Submitted to the Department of \@department \\
+    of \@institution \\
+    in partial fulfillment \\
+    of the requirements for the degree of \\
     \@degree
     \vfil
-    \centerline{\hbox to \wd0 {\hbox{}\hrulefill\hbox{}}}
-    \bigskip
-    \centerline{}
-    \bigskip
-    {\fontsize{12}{14}\selectfont \lineskip .75em
-    \begin{tabular}[t]{c}%
-      \@author
-    \end{tabular}\par}
-    \vskip 1.5em
-    {\fontsize{12}{14}\selectfont \@date \par}
-  \end{center}\par
+    \@advisor, Primary Faculty Advisor \\
+    \@altadvisor, Secondary Faculty Advisor \\
+    \vfil
+    \@date
+  \end{center}
   \end{titlepage}
+}}
 
-%% Approved for the division page
-  \cleardoublepage
-  {\fontsize{12}{14}
-  \setbox0=\hbox{Approved for the \@approvedforthe}
-  \thispagestyle{empty}
-  \null\vfil		% just below center of page
-  \par\vskip 6cm	% below center, not center
-  \centerline{\copy0}	% approved
-  \centerline{(\@department)} %major
-  \vskip 1cm		%space to sign
-  \centerline{\makebox[\wd0][c]{\hrulefill}
-	\if@altadvisor \makebox[.5in]{} \makebox[\wd0][c]{\hrulefill} \fi}
-  \centerline{\makebox[\wd0][c]{\@advisor}
-	\if@altadvisor \makebox[.5in]{} \makebox[\wd0][c]{\@altadvisor} \fi}
-  \par\vfil\null}
-  \cleardoublepage
-  }
-}
 
 % From JSS
 % Added by CII


### PR DESCRIPTION
Class file now generates a title page consistent with Smith's format. The secondary title page specific to Reed's format has been removed. Below is an example of how this looks when rendered (note that the full date just has not been entered yet -- it would show up with a day of the month as well):

![Screen Shot 2020-09-17 at 7 01 28 PM](https://user-images.githubusercontent.com/33032410/93536929-36ac1500-f918-11ea-9962-21a5d4d3aa2a.png)
