### PR TITLE
fix cslReferences error

### DIFF
--- a/inst/rmarkdown/templates/thesis/skeleton/template.tex
+++ b/inst/rmarkdown/templates/thesis/skeleton/template.tex
@@ -115,13 +115,34 @@ $endif$
 
 %Added by @MyKo101, code provided by @GerbrichFerdinands
 $if(csl-refs)$
+\newlength{\csllabelwidth}
+\setlength{\csllabelwidth}{3em}
 \newlength{\cslhangindent}
 \setlength{\cslhangindent}{1.5em}
+% for Pandoc 2.8 to 2.10.1
 \newenvironment{cslreferences}%
   {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
   \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
   {\par}
-$endif$
+% For Pandoc 2.11+
+% As noted by @mirh [2] is needed instead of [3] for 2.12
+\newenvironment{CSLReferences}[2] % #1 hanging-ident, #2 entry spacing
+ {% don't indent paragraphs
+\setlength{\parindent}{0pt}
+% turn on hanging indent if param 1 is 1
+\ifodd #1 \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces\fi
+% set entry spacing
+\ifnum #2 > 0
+\setlength{\parskip}{#2\baselineskip}
+  \fi
+}%
+{}
+\usepackage{calc} % for calculating minipage widths
+\newcommand{\CSLBlock}[1]{#1\hfill\break}
+  \newcommand{\CSLLeftMargin}[1]{\parbox[t]{\csllabelwidth}{#1}}
+    \newcommand{\CSLRightInline}[1]{\parbox[t]{\linewidth - \csllabelwidth}{#1}}
+      \newcommand{\CSLIndent}[1]{\hspace{\cslhangindent}#1}
+        $endif$
 
 \renewcommand{\contentsname}{Table of Contents}
 % End of CII addition


### PR DESCRIPTION
This fix resolves the error 'LatexError: environment cslReferences undefined'. The code is  obtained from [thesisdown template.tex](https://github.com/ismayc/thesisdown/blob/master/inst/rmarkdown/templates/thesis/skeleton/template.tex).